### PR TITLE
Fix CI configuration

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -205,8 +205,8 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
-          - name: "CentOS-7"
-            image: centos:7
+          - name: "CentOS-8"
+            image: centos:8
             cmp: gcc
             configuration: default
             extra: "CMD_CXXFLAGS=-std=c++11"
@@ -224,28 +224,17 @@ jobs:
             extra: "CMD_CXXFLAGS=-std=c++11"
 
     steps:
-    - name: "Build newer Git"
-      # actions/checkout@v2 wants git >=2.18
-      # centos:7 has 1.8
-      if: matrix.image=='centos:7'
+    - name: "Fix repo URLs on CentOS-8"
+      # centos:8 is frozen, repos are in the vault
+      if: matrix.image=='centos:8'
       run: |
-        yum -y install curl make gcc curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker
-        curl https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.29.0.tar.gz | tar -xz
-        cd git-*
-        make -j2 prefix=/usr/local all
-        make prefix=/usr/local install
-        cd ..
-        rm -rf git-*
-        type -a git
-        git --version
+        sed -i -e "s|mirrorlist=|#mirrorlist=|" \
+        -e "s|#baseurl=http://mirror|baseurl=http://vault|" \
+        /etc/yum.repos.d/CentOS-Linux-{BaseOS,AppStream,Extras,Plus}.repo
     - name: "Redhat setup"
       run: |
-        dnfyum() {
-            dnf -y "$@" || yum -y "$@"
-            return $?
-        }
-        dnfyum install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple
-        git --version || dnfyum install git
+        dnf -y install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple
+        git --version || dnf -y install git
         # rather than just bite the bullet and link python3 -> python,
         # people would rather just break all existing scripts...
         [ -e /usr/bin/python ] || ln -sf python3 /usr/bin/python
@@ -255,10 +244,6 @@ jobs:
         submodules: true
     - name: Automatic core dumper analysis
       uses: mdavidsaver/ci-core-dumper@master
-      if: matrix.image!='centos:7'
-    - name: Automatic core dumper analysis
-      uses: mdavidsaver/ci-core-dumper@node16
-      if: matrix.image=='centos:7'
     - name: Prepare and compile dependencies
       run: python .ci/cue.py prepare
     - name: Build main module

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -211,6 +211,12 @@ jobs:
             configuration: default
             extra: "CMD_CXXFLAGS=-std=c++11"
 
+          - name: "Rocky-9"
+            image: rockylinux:9
+            cmp: gcc
+            configuration: default
+            extra: "CMD_CXXFLAGS=-std=c++11"
+
           - name: "Fedora-33"
             image: fedora:33
             cmp: gcc

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -19,6 +19,7 @@ on:
       - '.gitattributes'
       - '**/*.html'
       - '**/*.md'
+  workflow_dispatch:
 
 env:
     SETUP_PATH: .ci-local:.ci
@@ -161,7 +162,7 @@ jobs:
             extra: "CMD_CXXFLAGS=-std=c++11"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Automatic core dumper analysis
@@ -249,11 +250,15 @@ jobs:
         # people would rather just break all existing scripts...
         [ -e /usr/bin/python ] || ln -sf python3 /usr/bin/python
         python --version
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Automatic core dumper analysis
       uses: mdavidsaver/ci-core-dumper@master
+      if: matrix.image!='centos:7'
+    - name: Automatic core dumper analysis
+      uses: mdavidsaver/ci-core-dumper@node16
+      if: matrix.image=='centos:7'
     - name: Prepare and compile dependencies
       run: python .ci/cue.py prepare
     - name: Build main module

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -42,6 +42,20 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
+          - name: "Ub-22 gcc-11 Base 7.0"
+            os: ubuntu-22.04
+            cmp: gcc
+            configuration: default
+            base: "7.0"
+            extra: "CMD_CXXFLAGS=-std=c++11"
+
+          - name: "Ub-22 gcc-11 static Base 7.0"
+            os: ubuntu-22.04
+            cmp: gcc
+            configuration: static
+            base: "7.0"
+            extra: "CMD_CXXFLAGS=-std=c++11"
+
           - name: "Ub-20 gcc-9 Base 7.0"
             os: ubuntu-20.04
             cmp: gcc
@@ -110,6 +124,13 @@ jobs:
 
           - name: "Ub-20 clang-10"
             os: ubuntu-20.04
+            cmp: clang
+            configuration: default
+            base: "7.0"
+            extra: "CMD_CXXFLAGS=-std=c++11"
+
+          - name: "Ub-22 clang-14"
+            os: ubuntu-22.04
             cmp: clang
             configuration: default
             base: "7.0"


### PR DESCRIPTION
- apply useful bits from EPICS Base
- replace hopeless CentOS-7 docker build with CentOS-8,
  clean up CentOS-7 debris
- add Rocky-9 to docker builds
- add jobs on Ubuntu 22.04